### PR TITLE
Fixed install error by automatically finding *all* packages

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,5 +1,5 @@
 
-from setuptools import setup
+from setuptools import setup, find_packages
 
 setup(name='gputools',
     version='0.1.1',
@@ -8,7 +8,7 @@ setup(name='gputools',
     author='Martin Weigert',
     author_email='mweigert@mpi-cbg.de',
     license='MIT',
-    packages=['gputools'],
+    packages=find_packages(),
     install_requires=["numpy","pyopencl","pyfft"],
     package_data={},
     entry_points = {}


### PR DESCRIPTION
I couldn't install gputools properly on my system, as the install only picked up the main package without all of the subpackages. This seems to fix it.

(P.S. I'm Robin - the chap you met at EuroSciPy earlier today!)