### PR TITLE
Python 3 compatibility

### DIFF
--- a/gputools/__init__.py
+++ b/gputools/__init__.py
@@ -3,8 +3,8 @@ from gputools.core.config import init_device, get_device
 from gputools.core.ocltypes import OCLArray, OCLImage
 from gputools.core.oclprogram import OCLProgram
 
-from gputools.fft.oclfft_convolve import fft_convolve
-from gputools.fft.oclfft import fft, fft_plan
+#from gputools.fft.oclfft_convolve import fft_convolve
+#from gputools.fft.oclfft import fft, fft_plan
 
 from gputools.convolve.convolve_sep import convolve_sep2, convolve_sep3
 
@@ -13,9 +13,9 @@ from gputools.convolve.convolve import convolve
 
 from gputools.core.oclalgos import OCLReductionKernel, OCLElementwiseKernel
 
-from gputools import denoise
+#from gputools import denoise
 
-from gputools import deconv
+#from gputools import deconv
 
 
 from gputools.transforms.scale import scale

--- a/gputools/convolve/convolve.py
+++ b/gputools/convolve/convolve.py
@@ -9,7 +9,7 @@ from gputools.core.ocltypes import assert_bufs_type
 
 import sys
 
-from abspath import abspath
+from .abspath import abspath
 
 
 
@@ -95,8 +95,8 @@ def _convolve3_old(data,h, dev = None):
     dtypes_options = {np.float32:"",
                       np.uint16:"-D SHORTTYPE"}
 
-    if not dtype in dtypes_options.keys():
-        raise TypeError("data type %s not supported yet, please convert to:"%dtype,dtypes_options.keys())
+    if not dtype in list(dtypes_options.keys()):
+        raise TypeError("data type %s not supported yet, please convert to:"%dtype,list(dtypes_options.keys()))
 
     prog = OCLProgram(abspath("kernels/convolve3.cl"),
                       build_options = dtypes_options[dtype])

--- a/gputools/convolve/convolve_sep.py
+++ b/gputools/convolve/convolve_sep.py
@@ -7,7 +7,7 @@ from gputools import OCLArray, OCLProgram, get_device
 
 from gputools.core.ocltypes import assert_bufs_type
 
-from abspath import abspath
+from .abspath import abspath
 
 # def _convolve_axis2_gpu(data_g, h_g, axis= 0, res_g=None, dev = None):
 #     if dev is None:
@@ -149,7 +149,7 @@ def test_3d():
     t = time()
     for _ in range(Niter):
         out = convolve_sep3(data,hx,hy, hz)
-    print "time: %.3f ms"%(1000.*(time()-t)/Niter)
+    print(("time: %.3f ms"%(1000.*(time()-t)/Niter)))
 
     data_g = OCLArray.from_array(data)
     hx_g = OCLArray.from_array(hx.astype(np.float32))
@@ -161,7 +161,7 @@ def test_3d():
         out_g = convolve_sep3(data_g,hx_g,hy_g, hz_g)
 
     out_g.get();
-    print "time: %.3f ms"%(1000.*(time()-t)/Niter)
+    print(("time: %.3f ms"%(1000.*(time()-t)/Niter)))
 
         
     return  out, out_g.get()

--- a/gputools/convolve/correlate.py
+++ b/gputools/convolve/correlate.py
@@ -4,7 +4,7 @@ logger = logging.getLogger(__name__)
 import numpy as np
 from PyOCL import OCLDevice, OCLProcessor, cl
 
-from convolve import convolve2
+from .convolve import convolve2
 
 def absPath(myPath):
     """ Get absolute path to resource, works for dev and for PyInstaller """
@@ -37,8 +37,8 @@ def _correlate2(data,h, dev = None):
     dtypes_kernels = {np.float32:"correlate2d_float",
                       np.uint16:"correlate2d_short"}
 
-    if not dtype in dtypes_kernels.keys():
-        raise TypeError("data type %s not supported yet, please convert to:"%dtype,dtypes_kernels.keys())
+    if not dtype in list(dtypes_kernels.keys()):
+        raise TypeError("data type %s not supported yet, please convert to:"%dtype,list(dtypes_kernels.keys()))
 
 
     proc = OCLProcessor(dev,absPath("kernels/correlate_kernels.cl"))
@@ -79,8 +79,8 @@ def correlate2(data,h, dev = None):
     dtypes_kernels = {np.float32:"mean_var_2d_float",
                       np.uint16:"mean_var_2d_short"}
 
-    if not dtype in dtypes_kernels.keys():
-        raise TypeError("data type %s not supported yet, please convert to:"%dtype,dtypes_kernels.keys())
+    if not dtype in list(dtypes_kernels.keys()):
+        raise TypeError("data type %s not supported yet, please convert to:"%dtype,list(dtypes_kernels.keys()))
 
 
     proc = OCLProcessor(dev,absPath("kernels/correlate_kernels.cl"))
@@ -103,7 +103,7 @@ def correlate2(data,h, dev = None):
 
     res = convolve2(dev,data-dataMean,h - hMean)
 
-    print hMean, hVar
+    print((hMean, hVar))
     # # res = convolve2(dev,data-dataMean,h)
 
     # return res

--- a/gputools/core/cl_error_codes.py
+++ b/gputools/core/cl_error_codes.py
@@ -65,12 +65,12 @@ _CL_ERROR_DICT_BY_NAME={
     ,"CL_INVALID_DEVICE_PARTITION_COUNT":-68
 }
 
-_CL_ERROR_DICT_BY_CODE = dict((code,name) for name,code in _CL_ERROR_DICT_BY_NAME.iteritems())
+_CL_ERROR_DICT_BY_CODE = dict((code,name) for name,code in list(_CL_ERROR_DICT_BY_NAME.items()))
 
 def create_exception_class(name):
     return type(name,(Exception,),{})
 
-globals().update(dict((name,create_exception_class(name)) for code ,name in _CL_ERROR_DICT_BY_CODE.iteritems()))
+globals().update(dict((name,create_exception_class(name)) for code ,name in list(_CL_ERROR_DICT_BY_CODE.items())))
 
 def _from_pycl_exception(e):
     if hasattr(e,"code"):

--- a/gputools/core/config.py
+++ b/gputools/core/config.py
@@ -13,7 +13,7 @@ cl_datatype_dict = {pyopencl.channel_type.FLOAT:np.float32,
                     pyopencl.channel_type.SIGNED_INT16:np.int16,
                     pyopencl.channel_type.SIGNED_INT32:np.int32}
 
-cl_datatype_dict.update({dtype:cltype for cltype,dtype in cl_datatype_dict.iteritems()})
+cl_datatype_dict.update({dtype:cltype for cltype,dtype in list(cl_datatype_dict.items())})
 
 
 

--- a/gputools/core/ocldevice.py
+++ b/gputools/core/ocldevice.py
@@ -58,18 +58,18 @@ class OCLDevice:
 
     def print_info(self):
         platforms = pyopencl.get_platforms()
-        print "\n-------- available devices -----------"
+        print("\n-------- available devices -----------")
         for p in platforms:
-            print "platform: \t",p.name
+            print(("platform: \t",p.name))
             printNames = [["CPU",pyopencl.device_type.CPU],
                           ["GPU",pyopencl.device_type.GPU]]
             for name, identifier in printNames:
-                print "device type: \t" , name
+                print(("device type: \t" , name))
                 try:
                     for d in p.get_devices(identifier):
-                        print "\t ", d.name
+                        print(("\t ", d.name))
                 except:
-                    print "nothing found: ", name
+                    print(("nothing found: ", name))
 
         infoKeys = ['NAME','GLOBAL_MEM_SIZE',
                     'GLOBAL_MEM_SIZE','MAX_MEM_ALLOC_SIZE',
@@ -78,10 +78,10 @@ class OCLDevice:
                     'IMAGE3D_MAX_HEIGHT','IMAGE3D_MAX_DEPTH',
                     'MAX_WORK_GROUP_SIZE','MAX_WORK_ITEM_SIZES']
 
-        print "\n-------- currently used device -------"
+        print("\n-------- currently used device -------")
 
         for k in infoKeys:
-            print "%s: \t  %s"% (k, self.get_info(k))
+            print(("%s: \t  %s"% (k, self.get_info(k))))
 
 
 

--- a/gputools/core/ocltypes.py
+++ b/gputools/core/ocltypes.py
@@ -11,6 +11,7 @@ import pyopencl
 from gputools import get_device
 
 import pyopencl.clmath as cl_math
+import collections
 
 
 def assert_bufs_type(mytype,*bufs):
@@ -81,7 +82,7 @@ def _wrap_OCLArray(cls):
         setattr(cls,f,wrap_module_func(cl_array,f))
 
     for f in dir(cl_math):
-        if callable(getattr(cl_math,f)):
+        if isinstance(getattr(cl_math,f), collections.Callable):
             setattr(cls,f,wrap_module_func(cl_math,f))
 
     
@@ -249,7 +250,7 @@ def test_types():
 
     for x in [b0,b1,b2,im0,im1,im2]:
         if hasattr(x,"sum"):
-            print "sum: %s" %x.sum()
+            print(("sum: %s" %x.sum()))
         assert np.allclose(d,x.get())
 
         

--- a/gputools/deconv/__init__.py
+++ b/gputools/deconv/__init__.py
@@ -1,1 +1,1 @@
-from deconv_rl import deconv_rl
+#from .deconv_rl import deconv_rl

--- a/gputools/deconv/deconv_rl.py
+++ b/gputools/deconv/deconv_rl.py
@@ -9,7 +9,7 @@ from gputools import OCLArray, OCLProgram, get_device
 from gputools import convolve, fft_convolve, fft, fft_plan
 from gputools import OCLElementwiseKernel
 
-from abspath import abspath
+from .abspath import abspath
 
 
 
@@ -106,7 +106,7 @@ def _deconv_rl_np_fft(data, h, Niter = 10,
     fft(hflip_f_g,inplace = True)
 
     for i in range(Niter):
-        print i
+        print(i)
         fft_convolve(u_g, hf_g,
                      res_g = tmp_g,
                      kernel_is_fft = True)
@@ -150,7 +150,7 @@ def _deconv_rl_gpu_fft(data_g, h_g, Niter = 10):
     fft(hflip_g,inplace = True)
 
     for i in range(Niter):
-        print i
+        print(i)
         fft_convolve(u_g, h_g,
                      res_g = tmp_g,
                      kernel_is_fft = True)
@@ -213,7 +213,7 @@ if __name__ == '__main__':
 
     y += 0.02*np.max(d)*np.random.uniform(0,1,d.shape)
 
-    print "start"
+    print("start")
 
     
     # u = deconv_rl(y,h, 1)

--- a/gputools/denoise/__init__.py
+++ b/gputools/denoise/__init__.py
@@ -1,5 +1,5 @@
-from nlm3 import nlm3
-from nlm2 import nlm2
-from bilateral2 import bilateral2
-from bilateral3 import bilateral3
+from .nlm3 import nlm3
+from .nlm2 import nlm2
+from .bilateral2 import bilateral2
+from .bilateral3 import bilateral3
 

--- a/gputools/denoise/bilateral2.py
+++ b/gputools/denoise/bilateral2.py
@@ -11,7 +11,7 @@ import numpy as np
 
 from gputools import OCLArray,OCLImage, OCLProgram, get_device
 
-from abspath import abspath
+from .abspath import abspath
 
 
 def bilateral2(data, fSize, sigma_p, sigma_x = 10.):
@@ -21,8 +21,8 @@ def bilateral2(data, fSize, sigma_p, sigma_x = 10.):
     dtypes_kernels = {np.float32:"bilat2_float",
                         np.uint16:"bilat2_short"}
 
-    if not dtype in dtypes_kernels.keys():
-        logger.info("data type %s not supported yet (%s), casting to float:"%(dtype,dtypes_kernels.keys()))
+    if not dtype in list(dtypes_kernels.keys()):
+        logger.info("data type %s not supported yet (%s), casting to float:"%(dtype,list(dtypes_kernels.keys())))
         data = data.astype(np.float32)
         dtype = data.dtype.type
 

--- a/gputools/denoise/bilateral3.py
+++ b/gputools/denoise/bilateral3.py
@@ -11,7 +11,7 @@ import numpy as np
 
 from gputools import OCLArray,OCLImage, OCLProgram, get_device
 
-from abspath import abspath
+from .abspath import abspath
 
 
 def bilateral3(data, size_filter, sigma_p, sigma_x = 10.):
@@ -20,8 +20,8 @@ def bilateral3(data, size_filter, sigma_p, sigma_x = 10.):
     dtype = data.dtype.type
     dtypes_kernels = {np.float32:"bilat3_float",}
 
-    if not dtype in dtypes_kernels.keys():
-        logger.info("data type %s not supported yet (%s), casting to float:"%(dtype,dtypes_kernels.keys()))
+    if not dtype in list(dtypes_kernels.keys()):
+        logger.info("data type %s not supported yet (%s), casting to float:"%(dtype,list(dtypes_kernels.keys())))
         data = data.astype(np.float32)
         dtype = data.dtype.type
 
@@ -32,7 +32,7 @@ def bilateral3(data, size_filter, sigma_p, sigma_x = 10.):
     
     prog = OCLProgram(abspath("kernels/bilateral3.cl"))
 
-    print img.shape
+    print((img.shape))
 
     prog.run_kernel(dtypes_kernels[dtype],
                     img.shape,None,

--- a/gputools/denoise/denoise_filter2.py
+++ b/gputools/denoise/denoise_filter2.py
@@ -23,8 +23,8 @@ def bilateral(data, fSize, sigma, sigma_x = 10., dev= None):
     dtypes_kernels = {np.float32:"run2d_float",
                         np.uint16:"run2d_short"}
 
-    if not dtype in dtypes_kernels.keys():
-        print "data type %s not supported yet, casting to float:"%dtype,dtypes_kernels.keys()
+    if not dtype in list(dtypes_kernels.keys()):
+        print(("data type %s not supported yet, casting to float:"%dtype,list(dtypes_kernels.keys())))
         return
 
 
@@ -121,8 +121,8 @@ def nlm(data, fSize, bSize, sigma, dev = None, proc = None):
     dtypes_kernels = {np.float32:"run2d_float",
                         np.uint16:"run2d_short"}
 
-    if not dtype in dtypes_kernels.keys():
-        print "data type %s not supported yet, please convert to:"%dtype,dtypes_kernels.keys()
+    if not dtype in list(dtypes_kernels.keys()):
+        print(("data type %s not supported yet, please convert to:"%dtype,list(dtypes_kernels.keys())))
         return
 
 
@@ -208,7 +208,7 @@ def test_nlm():
     sigs = np.linspace(2,70,10)
 
     outs  = [calcPSNR(data,nlm(y,2,3,s)) for s in sigs]
-    print "nlm: sig_max = %s" %sigs[np.argmax(outs)]
+    print(("nlm: sig_max = %s" %sigs[np.argmax(outs)]))
 
     return outs
 
@@ -231,10 +231,10 @@ def test_nlm_fast():
         y = data + np.random.normal(0,s0,data.shape)
         y = y.astype(np.float32)
         ind=np.argmax([calcPSNR(data,nlm_fast(y,2,3,s)) for s in sigs])
-        print ind
+        print(ind)
         bests.append([s0,sigs[ind]])
 
-    print "nlm fast: sig_max = %s" %sigs[np.argmax(outs)]
+    print(("nlm fast: sig_max = %s" %sigs[np.argmax(outs)]))
     return bests
 
 
@@ -445,7 +445,7 @@ def test_filter():
 
     data = np.random.uniform(0,1,[2**8,2**8]).astype(np.float32)
 
-    print "running on image shape : {} \n\n".format(data.shape)
+    print(("running on image shape : {} \n\n".format(data.shape)))
 
     fs = {
         "bilateral":lambda:bilateral(data,3,10,10),
@@ -461,9 +461,9 @@ def test_filter():
           }
 
     t = time.time()
-    for f in fs.keys():
+    for f in list(fs.keys()):
         fs[f]()
-        print "%s \t: \t %.2f s"%(f,time.time()-t)
+        print(("%s \t: \t %.2f s"%(f,time.time()-t)))
         t = time.time()
 
 

--- a/gputools/denoise/denoise_filter3.py
+++ b/gputools/denoise/denoise_filter3.py
@@ -41,8 +41,8 @@ def bilateral3(data, fSize, sigmaX, dev = None):
     dtypes_kernels = {np.float32:"run3_float",
                         np.uint16:"run3_short"}
 
-    if not dtype in dtypes_kernels.keys():
-        print "data type %s not supported yet, please convert to:"%dtype,dtypes_kernels.keys()
+    if not dtype in list(dtypes_kernels.keys()):
+        print(("data type %s not supported yet, please convert to:"%dtype,list(dtypes_kernels.keys())))
         return
 
     proc = OCLProcessor(dev,utils.absPath("kernels/bilateral.cl"))
@@ -76,8 +76,8 @@ def nlm3(data, fSize, bSize, sigma, dev = None):
     dtypes_kernels = {np.float32:"nlm3_float",
                         np.uint16:"nlm3_short"}
 
-    if not dtype in dtypes_kernels.keys():
-        print "data type %s not supported yet, please convert to:"%dtype,dtypes_kernels.keys()
+    if not dtype in list(dtypes_kernels.keys()):
+        print(("data type %s not supported yet, please convert to:"%dtype,list(dtypes_kernels.keys())))
         return
 
     proc = OCLProcessor(dev,utils.absPath("kernels/nlmeans3d.cl"))
@@ -87,7 +87,7 @@ def nlm3(data, fSize, bSize, sigma, dev = None):
     dev.writeImage(img,data)
 
 
-    print img.shape
+    print((img.shape))
     proc.runKernel(dtypes_kernels[dtype],img.shape,None,img,buf,
                      np.int32(img.width),np.int32(img.height),
                      np.int32(fSize), np.int32(bSize),np.float32(sigma))
@@ -178,7 +178,7 @@ def nlm3_fast(data,FS,BS,sigma,dev = None, proc = None):
     dtype = data.dtype.type
 
     if not dtype in [np.float32,np.uint16]:
-        print "data type %s not supported yet, please convert to:"%[np.float32,np.uint16]
+        print(("data type %s not supported yet, please convert to:"%[np.float32,np.uint16]))
         return
 
     if dtype == np.float32:
@@ -273,8 +273,8 @@ def test_nlm3_fast():
     t = time()
     out = nlm3_fast(dev,y,2,3,200)
 
-    print "time:", time()-t
-    print "PSNR: ",utils.calcPSNR(data,out)
+    print(("time:", time()-t))
+    print(("PSNR: ",utils.calcPSNR(data,out)))
     # sigs = np.linspace(3,70,30)
 
     # bests = []
@@ -297,7 +297,7 @@ def nlm3_thresh(dev, data, FS,BS, sigma, thresh= 0, mean = False):
     dtype = data.dtype.type
 
     if not dtype in [np.float32,np.uint16]:
-        print "data type %s not supported yet, please convert to:"%[np.float32,np.uint16]
+        print(("data type %s not supported yet, please convert to:"%[np.float32,np.uint16]))
         return
 
     if dtype == np.float32:
@@ -338,8 +338,8 @@ def test_nlm3_thresh():
     t = time()
     out = nlm3_thresh(dev,y,2,3,30,60)
 
-    print time()-t
-    print calcPSNR(data,out)
+    print((time()-t))
+    print((calcPSNR(data,out)))
     # sigs = np.linspace(3,70,30)
 
     # bests = []
@@ -404,8 +404,8 @@ def tv3_gpu(data,weight,Niter=50, Ncut = 1, dev = None):
         Nz,Ny,Nx = data.shape
         # a heuristic guess: Npad = Niter means perfect
         Npad = 1+Niter/2
-        for i0,(i,j,k) in enumerate(product(range(Ncut),repeat=3)):
-            print "calculating box  %i/%i"%(i0+1,Ncut**3)
+        for i0,(i,j,k) in enumerate(product(list(range(Ncut)),repeat=3)):
+            print(("calculating box  %i/%i"%(i0+1,Ncut**3)))
             sx = slice(i*Nx/Ncut,(i+1)*Nx/Ncut)
             sy = slice(j*Ny/Ncut,(j+1)*Ny/Ncut)
             sz = slice(k*Nz/Ncut,(k+1)*Nz/Ncut)
@@ -433,8 +433,8 @@ def test_tv3_gpu():
     t = time()
     out = tv3_gpu(dev,y,.4*np.amax(data))
 
-    print "time:", time()-t
-    print "PSNR: ",utils.calcPSNR(data,out)
+    print(("time:", time()-t))
+    print(("PSNR: ",utils.calcPSNR(data,out)))
     return data,y,out
 
 def bm4d(data,sigma):
@@ -461,7 +461,7 @@ def test_bm4d():
     y = y.astype(np.float32)
 
     out = bm4d(y,20)
-    print calcPSNR(data,out)
+    print((calcPSNR(data,out)))
     sigs = np.linspace(3,70,30)
 
     return data,out
@@ -522,10 +522,10 @@ def test_all():
                "wiener3":lambda x:wiener3(x,3.)
                }
 
-    for name, filter in filters.iteritems():
+    for name, filter in list(filters.items()):
         t = time()
-        filter(d);
-        print "running time = %2.f ms \t name = %s \t size = %s "%(1000.*(time()-t),name,d.shape)
+        list(filter(d));
+        print(("running time = %2.f ms \t name = %s \t size = %s "%(1000.*(time()-t),name,d.shape)))
 
 
 

--- a/gputools/denoise/nlm2.py
+++ b/gputools/denoise/nlm2.py
@@ -12,7 +12,7 @@ import numpy as np
 
 from gputools import OCLArray,OCLImage, OCLProgram, get_device
 
-from abspath import abspath
+from .abspath import abspath
 
 
 def nlm2(data,sigma, size_filter = 2, size_search = 3):

--- a/gputools/denoise/nlm3.py
+++ b/gputools/denoise/nlm3.py
@@ -12,7 +12,7 @@ import numpy as np
 
 from gputools import OCLArray,OCLImage, OCLProgram, get_device
 
-from abspath import abspath
+from .abspath import abspath
 
 
 def nlm3(data,sigma, size_filter = 2, size_search = 3):

--- a/gputools/fft/oclfft_convolve.py
+++ b/gputools/fft/oclfft_convolve.py
@@ -119,7 +119,7 @@ def _fft_convolve_gpu(data_g, h_g, res_g = None,
 
 
     #multiply in fourier domain
-    print res_g.dtype, res_g.nbytes
+    print((res_g.dtype, res_g.nbytes))
     _complex_multiply_kernel(res_g,kern_g)
 
     fft(res_g,inplace = True, inverse = True, plan = plan)
@@ -153,4 +153,4 @@ if __name__ == '__main__':
     out = fft_convolve(d,h, inplace = False)
 
     
-    print np.sum(abs(out_g.get())),N**2/9
+    print((np.sum(abs(out_g.get())),N**2/9))

--- a/gputools/transforms/quaternion.py
+++ b/gputools/transforms/quaternion.py
@@ -81,4 +81,4 @@ if __name__ == '__main__':
 
     for t in np.linspace(0,1,10):
         q = quaternion_slerp(q1,q2,t)
-        print t, q, q.norm()
+        print((t, q, q.norm()))

--- a/gputools/transforms/scale.py
+++ b/gputools/transforms/scale.py
@@ -11,7 +11,7 @@ import numpy as np
 from gputools import OCLArray, OCLImage, OCLProgram, get_device
 from gputools import OCLElementwiseKernel
 
-from abspath import abspath
+from .abspath import abspath
 
 
 def scale(data, scale = (1.,1.,1.), interp = "linear"):
@@ -26,8 +26,8 @@ def scale(data, scale = (1.,1.,1.), interp = "linear"):
 
     bop = {"linear":"","nearest":"-D USENEAREST"}
 
-    if not interp in bop.keys():
-        raise KeyError("interp = '%s' not defined ,valid: %s"%(interp,bop.keys()))
+    if not interp in list(bop.keys()):
+        raise KeyError("interp = '%s' not defined ,valid: %s"%(interp,list(bop.keys())))
     
     if not isinstance(scale,(tuple, list, np.ndarray)):
         scale = (scale,)*3

--- a/gputools/transforms/transformations.py
+++ b/gputools/transforms/transformations.py
@@ -11,10 +11,10 @@ import numpy as np
 from gputools import OCLArray, OCLImage, OCLProgram, get_device
 from gputools import OCLElementwiseKernel
 
-from abspath import abspath
+from .abspath import abspath
 
 
-from quaternion import Quaternion 
+from .quaternion import Quaternion 
 
 
 
@@ -39,8 +39,8 @@ def affine(data, mat = np.identity(4), interp = "linear"):
 
     bop = {"linear":"","nearest":"-D USENEAREST"}
 
-    if not interp in bop.keys():
-        raise KeyError("interp = '%s' not defined ,valid: %s"%(interp,bop.keys()))
+    if not interp in list(bop.keys()):
+        raise KeyError("interp = '%s' not defined ,valid: %s"%(interp,list(bop.keys())))
     
     d_im = OCLImage.from_array(data)
     res_g = OCLArray.empty(data.shape,np.float32)

--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,7 @@ setup(name='gputools',
     author_email='mweigert@mpi-cbg.de',
     license='MIT',
     packages=['gputools'],
-    install_requires=["numpy","pyopencl","pyfft"],
+    install_requires=["numpy","pyopencl"],
     package_data={},
     entry_points = {}
 )

--- a/tests/core/test_ocltypes.py
+++ b/tests/core/test_ocltypes.py
@@ -31,7 +31,7 @@ def test_all():
     for N in Ns:
         for ndim in ndims:
             shape = [N+n for n in ndims[:ndim]]
-            print "testing %s"%(shape)
+            print(("testing %s"%(shape)))
             data = np.linspace(0,1,np.prod(shape)).reshape(shape).astype(np.float32)
             image_create_write(data)
             image_from_array(data)

--- a/tests/test_compare_fft.py
+++ b/tests/test_compare_fft.py
@@ -48,7 +48,7 @@ if __name__ == "__main__":
     ndim = 3
 
     t1 = [fft_np((n,)*ndim,2) for n in ns]
-    print "finished t1"
+    print("finished t1")
 
     t2 = [fft_gpu((n,)*ndim,6) for n in ns]
 

--- a/tests/test_convolve.py
+++ b/tests/test_convolve.py
@@ -27,10 +27,10 @@ if __name__ == '__main__':
     
     t = time()
     res1 = convolve2d(d,h,mode="same")
-    print time()-t
+    print((time()-t))
 
     t = time()    
     res2 = gputools.fft_convolve(d,h)
-    print time()-t
+    print((time()-t))
     
     


### PR DESCRIPTION
**Note:** This PR is not ready to be merged yet, it is just a way to start discussion...

I've managed to get parts of gputools working on Python 3 :-) Basically I've commented out all of the bits that use `pyfft`, and then dealt with various other Py2->Py3 stuff (eg. `print` needing brackets etc) and the convolution functions all seem to work.

I've had a bit of a look at the documentation for `reikna` (http://reikna.publicfields.net/en/latest/) and I can't really understand it. Do you think there is any easy way to replace `pyfft` with `reikna`? If so, then it would probably be reasonably easy to get the whole of `gputools` working on Python 3.

(If not, is it worth opening an issue saying that `reikna` is the suggested replacement for `pyfft` but it's not very easy to replicate the functionality?)
