### PR TITLE
Fixed import error resulting from image resampled feature

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -13,7 +13,8 @@ setup(name='gputools',
     install_requires=["numpy","pyopencl","pyfft"],
 
     package_data={"gputools":
-                  ['convolve/kernels/*l',
+                  ['core/kernels/*',
+                   'convolve/kernels/*l',
                    'denoise/kernels/*',
                    'deconv/kernels/*',
                    'transforms/kernels/*',


### PR DESCRIPTION
In [1]: import gputools
INFO:gputools.core.ocldevice | using device: GeForce GTX 980
---------------------------------------------------------------------------
IOError                                   Traceback (most recent call last)
<ipython-input-1-a8e6140ce46c> in <module>()
----> 1 import gputools

/usr/local/lib/python2.7/dist-packages/gputools-0.1.1-py2.7.egg/gputools/__init__.py in <module>()
      7 from gputools.core.config import init_device, get_device
      8 
----> 9 from gputools.core.ocltypes import OCLArray, OCLImage
     10 from gputools.core.oclprogram import OCLProgram
     11 

/usr/local/lib/python2.7/dist-packages/gputools-0.1.1-py2.7.egg/gputools/core/ocltypes.py in <module>()
    326 
    327 
--> 328 OCLArray = _wrap_OCLArray(cl_array.Array)
    329 OCLImage = _wrap_OCLImage(cl.Image)
    330 

/usr/local/lib/python2.7/dist-packages/gputools-0.1.1-py2.7.egg/gputools/core/ocltypes.py in _wrap_OCLArray(cls)
    117     cls.write_array = write_array
    118 
--> 119     cls._resample_prog = OCLProgram(abspath("kernels/copy_resampled.cl"))
    120 
    121     for f in ["sum","max","min","dot","vdot"]:

/usr/local/lib/python2.7/dist-packages/gputools-0.1.1-py2.7.egg/gputools/core/oclprogram.pyc in __init__(self, file_name, src_str, build_options, dev)
     26     def __init__(self,file_name = None,src_str = None, build_options =[], dev = None):
     27         if file_name is not None:
---> 28             with open(file_name,"r") as f:
     29                 src_str = f.read()
     30 

IOError: [Errno 2] No such file or directory: '/usr/local/lib/python2.7/dist-packages/gputools-0.1.1-py2.7.egg/gputools/core/kernels/copy_resampled.cl'
