### PR TITLE
New edge-mode parameter for affine transform

### DIFF
--- a/gputools/transforms/kernels/transformations.cl
+++ b/gputools/transforms/kernels/transformations.cl
@@ -5,19 +5,27 @@
 #define SAMPLERFILTER CLK_FILTER_LINEAR
 #endif
 
+#ifdef ADDNONE
+#define SAMPLERADDRESS CLK_ADDRESS_NONE
+#elif defined CLAMP
+#define SAMPLERADDRESS CLK_ADDRESS_CLAMP
+#else
+#define SAMPLERADDRESS CLK_ADDRESS_CLAMP_TO_EDGE
+#endif
 
-__kernel void affine(__read_only image3d_t input, 
-	      			 __global float* output, 
-				 __constant float * mat)	 
+
+__kernel void affine(__read_only image3d_t input,
+	      			 __global float* output,
+				 __constant float * mat)
 {
 
   const sampler_t sampler = CLK_NORMALIZED_COORDS_FALSE |
-      CLK_ADDRESS_CLAMP_TO_EDGE |	SAMPLERFILTER;
+      SAMPLERADDRESS |	SAMPLERFILTER;
 
   uint i = get_global_id(0);
   uint j = get_global_id(1);
   uint k = get_global_id(2);
-  
+
   uint Nx = get_global_size(0);
   uint Ny = get_global_size(1);
   uint Nz = get_global_size(2);
@@ -33,7 +41,7 @@ __kernel void affine(__read_only image3d_t input,
   float pix = read_imagef(input,sampler,(float4)(x,y,z,0)).x;
 
   output[i+Nx*j+Nx*Ny*k] = pix;
- 
+
 
 }
 

--- a/gputools/transforms/transformations.py
+++ b/gputools/transforms/transformations.py
@@ -20,16 +20,24 @@ from ._abspath import abspath
 
 
 
-def affine(data, mat = np.identity(4), mode ="linear"):
+def affine(data, mat = np.identity(4), mode ="linear", edge="repeat"):
     """affine transform data with matrix mat
 
-    """ 
+    """
 
     bop = {"linear":[],"nearest":["-D","USENEAREST"]}
 
     if not mode in bop:
         raise KeyError("mode = '%s' not defined ,valid: %s"%(mode, list(bop.keys())))
-    
+
+    edge_options = {'repeat' : [],
+                    'border' : ["-D", "CLAMP"],
+                    'none'   : ["-D", "ADDNONE"]}
+    if not edge in edge_options:
+        raise KeyError("edge = '%s' not defined ,valid: %s" % (
+            edge, list(edge_options.keys())))
+    bop[mode].extend(edge_options[edge])
+
     d_im = OCLImage.from_array(data)
     res_g = OCLArray.empty(data.shape,np.float32)
     mat_g = OCLArray.from_array(np.linalg.inv(mat).astype(np.float32,copy=False))
@@ -82,12 +90,12 @@ def rotate(data, center = None, axis = (1.,0,0), angle = 0., mode ="linear"):
 
 
 if __name__ == '__main__':
-    
+
     d = np.zeros((200,200,200),np.float32)
     d[20:-20,20:-20,20:-20] = 1.
 
     # res = translate(d, x = 10, y = 5, z= -10 )
     res = rotate(d,center = (100,100,100),angle = .5 )
 
-    
-    
+
+


### PR DESCRIPTION
Simple modification to allow gputools.transforms.transformations.affine to use other addressing-modes besides CLK_ADDRESS_CLAMP_TO_EDGE