### PR TITLE
convert print statements to logging module

### DIFF
--- a/gputools/config/myconfigparser.py
+++ b/gputools/config/myconfigparser.py
@@ -34,7 +34,7 @@ class MyConfigParser(SafeConfigParser):
                     self.read_file(f)
 
         except Exception as e:
-            print(e)
+            logger.warn(e)
 
 
 

--- a/gputools/convolve/convolve_spatial2.py
+++ b/gputools/convolve/convolve_spatial2.py
@@ -15,6 +15,8 @@ from gputools.utils.tile_iterator import tile_iterator
 
 from ._abspath import abspath
 
+import logging
+logger = logging.getLogger(__name__)
 
 def convolve_spatial2(im, psfs,
                       mode = "constant",
@@ -137,7 +139,10 @@ def convolve_spatial2(im, psfs,
         Npads = [n*(s>1) for n,s  in zip(Nblocks, sub_blocks)]
         grid_dim_sub = [g//s+2*(s>1) for g,s   in zip(Gs, sub_blocks)]
 
-        print(N_sub, Nblocks, grid_dim_sub, Npads)
+        logger.debug(
+            "N_sub: {}, Nblocks: {}, grid_dim_sub, {}, Npads, {}".format(
+                N_sub, Nblocks, grid_dim_sub, Npads
+            ))
 
         if grid_dim:
             res = np.empty(im.shape, np.float32)
@@ -271,7 +276,7 @@ def _convolve_spatial2(im, hs,
     fft(patches_g,inplace=True, inverse = True, plan = plan)
 
 
-    print(Nblock_x, Npatch_x)
+    logger.debug("Nblock_x: {}, Npatch_x: {}".format(Nblock_x, Npatch_x))
     #return np.abs(patches_g.get())
     #accumulate
     res_g = OCLArray.empty(im.shape,np.float32)

--- a/gputools/core/ocldevice.py
+++ b/gputools/core/ocldevice.py
@@ -102,7 +102,7 @@ class OCLDevice:
                                                                  pyopencl.mem_flags.READ_WRITE,
                                                                  pyopencl.mem_object_type.IMAGE3D)
 
-        print(self.device)
+        logger.info("intialized, device: {}".format(self.device))
         if print_info:
             self.print_info()
 

--- a/gputools/deconv/deconv_rl.py
+++ b/gputools/deconv/deconv_rl.py
@@ -123,7 +123,7 @@ def _deconv_rl_np_fft(data, h, Niter=10,
 
     data and h have to be same shape
 
-    
+
     via lucy richardson deconvolution
     """
 
@@ -153,7 +153,7 @@ def _deconv_rl_np_fft(data, h, Niter=10,
     fft(hflip_f_g, inplace=True)
 
     for i in range(Niter):
-        print(i)
+        logger.info("Iteration: {}".format(i))
         fft_convolve(u_g, hf_g,
                      res_g=tmp_g,
                      kernel_is_fft=True)
@@ -170,7 +170,7 @@ def _deconv_rl_np_fft(data, h, Niter=10,
 
 
 def _deconv_rl_gpu_fft(data_g, h_g, Niter=10):
-    """ 
+    """
     using fft_convolve
 
     """
@@ -195,7 +195,7 @@ def _deconv_rl_gpu_fft(data_g, h_g, Niter=10):
     fft(hflip_g, inplace=True)
 
     for i in range(Niter):
-        print(i)
+        logger.info("Iteration: {}".format(i))
         fft_convolve(u_g, h_g,
                      res_g=tmp_g,
                      kernel_is_fft=True)

--- a/gputools/denoise/bilateral3.py
+++ b/gputools/denoise/bilateral3.py
@@ -16,7 +16,7 @@ from ._abspath import abspath
 
 def bilateral3(data, size_filter, sigma_p, sigma_x = 10.):
     """bilateral filter """
-    
+
     dtype = data.dtype.type
     dtypes_kernels = {np.float32:"bilat3_float",}
 
@@ -29,10 +29,10 @@ def bilateral3(data, size_filter, sigma_p, sigma_x = 10.):
     img = OCLImage.from_array(data)
     res = OCLArray.empty_like(data)
 
-    
+
     prog = OCLProgram(abspath("kernels/bilateral3.cl"))
 
-    print(img.shape)
+    logger.debug("in bilateral3, image shape: {}".format(img.shape))
 
     prog.run_kernel(dtypes_kernels[dtype],
                     img.shape,None,

--- a/gputools/denoise/denoise_filter2.py
+++ b/gputools/denoise/denoise_filter2.py
@@ -7,7 +7,8 @@ MW, 2014
 from __future__ import print_function, unicode_literals, absolute_import, division
 import numpy as np
 import subprocess
-
+import logging
+logger = logging.getLogger(__name__)
 
 
 def bilateral(data, fSize, sigma, sigma_x = 10., dev= None):
@@ -24,7 +25,7 @@ def bilateral(data, fSize, sigma, sigma_x = 10., dev= None):
                         np.uint16:"run2d_short"}
 
     if not dtype in dtypes_kernels:
-        print("data type %s not supported yet, casting to float:"%dtype,list(dtypes_kernels.keys()))
+        logger.error("data type %s not supported yet, casting to float:"%dtype,list(dtypes_kernels.keys()))
         return
 
 
@@ -122,7 +123,7 @@ def nlm(data, fSize, bSize, sigma, dev = None, proc = None):
                         np.uint16:"run2d_short"}
 
     if not dtype in dtypes_kernels:
-        print("data type %s not supported yet, please convert to:"%dtype,list(dtypes_kernels.keys()))
+        logger.error("data type %s not supported yet, please convert to:"%dtype,list(dtypes_kernels.keys()))
         return
 
 

--- a/gputools/denoise/denoise_filter3.py
+++ b/gputools/denoise/denoise_filter3.py
@@ -15,7 +15,8 @@ from itertools import product
 import utils
 import imgtools
 from time import time
-
+import logging
+logger = logging.getLogger(__name__)
 
 def absPath(myPath):
     """ Get absolute path to resource, works for dev and for PyInstaller """
@@ -42,7 +43,7 @@ def bilateral3(data, fSize, sigmaX, dev = None):
                         np.uint16:"run3_short"}
 
     if not dtype in dtypes_kernels:
-        print("data type %s not supported yet, please convert to:"%dtype,list(dtypes_kernels.keys()))
+        logger.error("data type %s not supported yet, please convert to:"%dtype,list(dtypes_kernels.keys()))
         return
 
     proc = OCLProcessor(dev,utils.absPath("kernels/bilateral.cl"))
@@ -77,7 +78,7 @@ def nlm3(data, fSize, bSize, sigma, dev = None):
                         np.uint16:"nlm3_short"}
 
     if not dtype in dtypes_kernels:
-        print("data type %s not supported yet, please convert to:"%dtype,list(dtypes_kernels.keys()))
+        logger.error("data type %s not supported yet, please convert to:"%dtype,list(dtypes_kernels.keys()))
         return
 
     proc = OCLProcessor(dev,utils.absPath("kernels/nlmeans3d.cl"))
@@ -87,7 +88,7 @@ def nlm3(data, fSize, bSize, sigma, dev = None):
     dev.writeImage(img,data)
 
 
-    print(img.shape)
+    logger.debug("nlm3, image shape: {}".format(img.shape))
     proc.runKernel(dtypes_kernels[dtype],img.shape,None,img,buf,
                      np.int32(img.width),np.int32(img.height),
                      np.int32(fSize), np.int32(bSize),np.float32(sigma))
@@ -178,7 +179,7 @@ def nlm3_fast(data,FS,BS,sigma,dev = None, proc = None):
     dtype = data.dtype.type
 
     if not dtype in [np.float32,np.uint16]:
-        print("data type %s not supported yet, please convert to:"%[np.float32,np.uint16])
+        logger.error("data type %s not supported yet, please convert to:"%[np.float32,np.uint16])
         return
 
     if dtype == np.float32:
@@ -297,7 +298,7 @@ def nlm3_thresh(dev, data, FS,BS, sigma, thresh= 0, mean = False):
     dtype = data.dtype.type
 
     if not dtype in [np.float32,np.uint16]:
-        print("data type %s not supported yet, please convert to:"%[np.float32,np.uint16])
+        logger.error("data type %s not supported yet, please convert to:"%[np.float32,np.uint16])
         return
 
     if dtype == np.float32:
@@ -405,7 +406,7 @@ def tv3_gpu(data,weight,Niter=50, Ncut = 1, dev = None):
         # a heuristic guess: Npad = Niter means perfect
         Npad = 1+Niter/2
         for i0,(i,j,k) in enumerate(product(list(range(Ncut)),repeat=3)):
-            print("calculating box  %i/%i"%(i0+1,Ncut**3))
+            logger.info("calculating box  %i/%i"%(i0+1,Ncut**3))
             sx = slice(i*Nx/Ncut,(i+1)*Nx/Ncut)
             sy = slice(j*Ny/Ncut,(j+1)*Ny/Ncut)
             sz = slice(k*Nz/Ncut,(k+1)*Nz/Ncut)

--- a/gputools/denoise/tv2.py
+++ b/gputools/denoise/tv2.py
@@ -62,7 +62,7 @@ def _tv2(data,weight,Niter=50):
         # a heuristic guess: Npad = Niter means perfect
         Npad = 1+Niter/2
         for i0,(i,j,k) in enumerate(product(list(range(Ncut)),repeat=3)):
-            print("calculating box  %i/%i"%(i0+1,Ncut**3))
+            logger.info("calculating box  %i/%i"%(i0+1,Ncut**3))
             sx = slice(i*Nx/Ncut,(i+1)*Nx/Ncut)
             sy = slice(j*Ny/Ncut,(j+1)*Ny/Ncut)
             sz = slice(k*Nz/Ncut,(k+1)*Nz/Ncut)
@@ -83,7 +83,7 @@ def tv2(data,weight,Niter=50):
 
     weight should be around  2+1.5*noise_sigma
     """
-    
+
     prog = OCLProgram(abspath("kernels/tv2.cl"))
 
     data_im = OCLImage.from_array(data.astype(np,float32,copy=False))
@@ -116,7 +116,7 @@ def tv2(data,weight,Niter=50):
 
 if __name__ == '__main__':
     from scipy.misc import lena
-    
+
     d = lena()
 
     d = np.random.poisson(d,d.shape)


### PR DESCRIPTION
this PR just converts print statements that are not in `if __name__ == "__main__":` or obvious `test()` functions to use the logging module.  `logger = logging.getLogger(__name__)` was used where logging was not already imported.  The one that crops up the most is the print statement in the try/except when loading a config file at ~/.gputools that does not exist. 