### PR TITLE
added pragma statement to enable 3d texture

### DIFF
--- a/gputools/convolve/kernels/correlate_kernels.cl
+++ b/gputools/convolve/kernels/correlate_kernels.cl
@@ -1,3 +1,5 @@
+ #pragma OPENCL EXTENSION cl_khr_3d_image_writes : enable
+ 
 __kernel void mean_var_2d_float(__read_only image2d_t input,const int xStride,const int Nx,const int Ny,
 								__global float * output_mean,__global float *  output_var){
 

--- a/gputools/core/kernels/copy_resampled.cl
+++ b/gputools/core/kernels/copy_resampled.cl
@@ -1,4 +1,5 @@
-    #include <pyopencl-complex.h>
+#include <pyopencl-complex.h>
+#pragma OPENCL EXTENSION cl_khr_3d_image_writes : enable
 
 ////////// IMAGE ----> BUFFER
 

--- a/gputools/denoise/kernels/nlm_fast3.cl
+++ b/gputools/denoise/kernels/nlm_fast3.cl
@@ -25,7 +25,8 @@
 
 #endif
 
-
+ #pragma OPENCL EXTENSION cl_khr_3d_image_writes : enable
+ 
 __kernel void dist(__read_only image3d_t input,__write_only image3d_t output, const int dx,const int dy,const int dz){
 
 

--- a/gputools/denoise/kernels/tv_chambolle.cl
+++ b/gputools/denoise/kernels/tv_chambolle.cl
@@ -1,5 +1,6 @@
 
-
+ #pragma OPENCL EXTENSION cl_khr_3d_image_writes : enable
+ 
 __kernel void div_step(__read_only image3d_t input,__read_only image3d_t pDeriv,__write_only image3d_t output){
 
   


### PR DESCRIPTION
with these changes I can now `import gputools` without error message.
I tried this yesterday, but a whitespace before one of the `#pragma` statements threw a spanner in the works.