### PR TITLE
Add support for mode reflect in convolve spatial

### DIFF
--- a/gputools/convolve/convolve.py
+++ b/gputools/convolve/convolve.py
@@ -23,6 +23,7 @@ def convolve(data, h, res_g=None, sub_blocks=None, mode='constant'):
     boundary conditions are clamping to zero at edge.
     
     """
+    sub_blocks = sub_blocks or (1,) * data.ndim
 
     if not len(data.shape) in [1, 2, 3]:
         raise ValueError("dim = %s not supported" % (len(data.shape)))
@@ -33,8 +34,8 @@ def convolve(data, h, res_g=None, sub_blocks=None, mode='constant'):
     if isinstance(data, OCLArray) and isinstance(h, OCLArray):
         return _convolve_buf(data, h, res_g)
     elif isinstance(data, np.ndarray) and isinstance(h, np.ndarray):
-        if sub_blocks == (1,) * len(data.shape) or sub_blocks is None:
-            return _convolve_np(data, h)
+        if sub_blocks == (1,) * data.ndim and mode == 'constant':
+            res = _convolve_np(data, h)
         else:
             # cut the image into tile and operate on every of them
             N_sub = [int(np.ceil(1. * n / s)) for n, s in zip(data.shape, sub_blocks)]
@@ -47,7 +48,7 @@ def convolve(data, h, res_g=None, sub_blocks=None, mode='constant'):
                 res_tile = _convolve_np(data_tile.copy(),
                                         h)
                 res[data_s_src] = res_tile[data_s_dest]
-            return res
+        return res
     else:
         raise TypeError("unknown types (%s, %s)" % (type(data), type(h)))
 

--- a/gputools/convolve/convolve.py
+++ b/gputools/convolve/convolve.py
@@ -3,13 +3,11 @@ import logging
 
 logger = logging.getLogger(__name__)
 
-import os
 import numpy as np
 
 from gputools import OCLProgram, OCLArray, OCLImage, get_device
 from gputools.core.ocltypes import assert_bufs_type
 from gputools.utils.tile_iterator import tile_iterator
-import sys
 
 import pyopencl as cl
 from ._abspath import abspath

--- a/gputools/convolve/convolve.py
+++ b/gputools/convolve/convolve.py
@@ -15,7 +15,7 @@ import pyopencl as cl
 from ._abspath import abspath
 
 
-def convolve(data, h, res_g=None, sub_blocks=None):
+def convolve(data, h, res_g=None, sub_blocks=None, mode='constant'):
     """
     convolves 1d-3d data with kernel h 
 
@@ -45,7 +45,7 @@ def convolve(data, h, res_g=None, sub_blocks=None):
             for data_tile, data_s_src, data_s_dest \
                     in tile_iterator(data, blocksize=N_sub,
                                      padsize=Npads,
-                                     mode="constant"):
+                                     mode=mode):
                 res_tile = _convolve_np(data_tile.copy(),
                                         h)
                 res[data_s_src] = res_tile[data_s_dest]

--- a/gputools/convolve/convolve_spatial2.py
+++ b/gputools/convolve/convolve_spatial2.py
@@ -202,7 +202,6 @@ def _convolve_spatial2(im, hs,
     else:
         Gs = hs.shape[:2]
 
-
     mode_str = {"constant":"CLK_ADDRESS_CLAMP",
                 "wrap":"CLK_ADDRESS_REPEAT",
                 "nearest":"CLK_ADDRESS_CLAMP_TO_EDGE",
@@ -211,14 +210,11 @@ def _convolve_spatial2(im, hs,
     Ny, Nx = im.shape
     Gy, Gx = Gs
 
-
     # the size of each block within the grid
     Nblock_y, Nblock_x = Ny // Gy, Nx // Gx
 
-
     # the size of the overlapping patches with safety padding
     Npatch_x, Npatch_y = _next_power_of_2(pad_factor*Nblock_x), _next_power_of_2(pad_factor*Nblock_y)
-
 
     prog = OCLProgram(abspath("kernels/conv_spatial2.cl"),
                       build_options=["-D","ADDRESSMODE=%s"%mode_str[mode]])
@@ -228,7 +224,6 @@ def _convolve_spatial2(im, hs,
 
     x0s = Nblock_x*np.arange(Gx)
     y0s = Nblock_y*np.arange(Gy)
-
 
     patches_g = OCLArray.empty((Gy,Gx,Npatch_y,Npatch_x),np.complex64)
 
@@ -255,7 +250,6 @@ def _convolve_spatial2(im, hs,
         hs = np.fft.fftshift(pad_to_shape(hs,(Gy,Gx,Npatch_y,Npatch_x)),axes=(2,3))
         h_g = OCLArray.from_array(hs.astype(np.complex64))
 
-
     #prepare image
     im_g = OCLImage.from_array(im.astype(np.float32,copy=False))
 
@@ -268,7 +262,6 @@ def _convolve_spatial2(im, hs,
                     patches_g.data,
                     np.int32(i*Npatch_x*Npatch_y+j*Gx*Npatch_x*Npatch_y))
 
-
     #return np.abs(patches_g.get())
     # convolution
     fft(patches_g,inplace=True,  plan = plan)
@@ -276,7 +269,6 @@ def _convolve_spatial2(im, hs,
     prog.run_kernel("mult_inplace",(Npatch_x*Npatch_y*Gx*Gy,),None,
                     patches_g.data, h_g.data)
     fft(patches_g,inplace=True, inverse = True, plan = plan)
-
 
     logger.debug("Nblock_x: {}, Npatch_x: {}".format(Nblock_x, Npatch_x))
     #return np.abs(patches_g.get())

--- a/gputools/convolve/convolve_spatial2.py
+++ b/gputools/convolve/convolve_spatial2.py
@@ -79,7 +79,7 @@ def convolve_spatial2(im, psfs,
         the (Gx,Gy) psf grid, either of shape (Gx,Gy, Hy, Hx) or im.shape
 
     mode: string, optional
-        padding mode, either "constant" or "wrap"
+        Padding mode. Can be "constant", "wrap", "edge", or "reflect".
     grid_dim: tuple, optional
         the (Gy,Gx) grid dimension, has to be provided if psfs.shape = im.shape
 
@@ -204,7 +204,9 @@ def _convolve_spatial2(im, hs,
 
 
     mode_str = {"constant":"CLK_ADDRESS_CLAMP",
-                "wrap":"CLK_ADDRESS_REPEAT"}
+                "wrap":"CLK_ADDRESS_REPEAT",
+                "nearest":"CLK_ADDRESS_CLAMP_TO_EDGE",
+                "reflect":"CLK_ADDRESS_MIRRORED_REPEAT"}
 
     Ny, Nx = im.shape
     Gy, Gx = Gs

--- a/gputools/convolve/convolve_spatial2.py
+++ b/gputools/convolve/convolve_spatial2.py
@@ -191,10 +191,11 @@ def _convolve_spatial2(im, hs,
     Nx % Gx == 0
     Ny % Gy == 0
 
-
     mode can be:
     "constant" - assumed values to be zero
     "wrap" - periodic boundary condition
+    "nearest" - values repeat the value at the edge of the image
+    "reflect" - values are reflected around the edge of the image
     """
 
     if grid_dim:

--- a/gputools/convolve/convolve_spatial3.py
+++ b/gputools/convolve/convolve_spatial3.py
@@ -81,7 +81,7 @@ def convolve_spatial3(im, psfs,
         the (Gx,Gy) psf grid, either of shape (Gx,Gy, Hy, Hx) or im.shape
 
     mode: string, optional
-        padding mode, either "constant" or "wrap"
+        Padding mode. Can be "constant", "wrap", "edge", or "reflect".
     grid_dim: tuple, optional
         the (Gy,Gx) grid dimension, has to be provided if psfs.shape = im.shape
 
@@ -200,8 +200,10 @@ def _convolve_spatial3(im, hs,
         raise NotImplementedError(
             "shape of image has to be divisible by Gx Gy  = %s shape mismatch" % (str(hs.shape[:2])))
 
-    mode_str = {"constant": "CLK_ADDRESS_CLAMP",
-                "wrap": "CLK_ADDRESS_REPEAT"}
+    mode_str = {"constant":"CLK_ADDRESS_CLAMP",
+                "wrap":"CLK_ADDRESS_REPEAT",
+                "nearest":"CLK_ADDRESS_CLAMP_TO_EDGE",
+                "reflect":"CLK_ADDRESS_MIRRORED_REPEAT"}
 
     Ns = im.shape
 

--- a/gputools/separable/separable_approx.py
+++ b/gputools/separable/separable_approx.py
@@ -56,7 +56,7 @@ def _splitrank3(h, verbose=False):
     if np.sum(np.abs(h))<1.e-30:
         return tuple(np.zeros(s) for s in h.shape)+(np.zeros_like(h),)
 
-    P, fit, itr, exectimes = cp_als(dtensor(h.copy()), 1)
+    P, fit, itr = cp_als(dtensor(h.copy()), 1)[:3]  # ensure backwards compat
     hx, hy, hz = [(P.lmbda[0]) ** (1. / 3) * np.array(P.U[i])[:, 0] for i in range(3)]
     if verbose:
         print("lambdas= %s \nfit = %s \niterations= %s " % (P.lmbda, fit, itr))

--- a/gputools/utils/tile_iterator.py
+++ b/gputools/utils/tile_iterator.py
@@ -74,25 +74,13 @@ def tile_iterator(im,
 
     # iterates over cartesian product of subgrids
     for i,index in enumerate(product(*[range(sg) for sg in subgrids])):
-        # the slices
-        # if verbose:
-        #     print("tile %s/%s"%(i+1,np.prod(subgrids)))
-
         # dest[s_output] is where we will write to
         s_input = tuple([slice(i*b,(i+1)*b) for i,b in zip(index, blocksize)])
 
-
-
-        s_output = tuple([slice(p,-p-pm*(i==s-1)) for pm,p,i,s in zip(pad_mismatch,padsize, index, subgrids)])
-
-
         s_output = tuple([slice(p,b+p-pm*(i==s-1)) for b,pm,p,i,s in zip(blocksize,pad_mismatch,padsize, index, subgrids)])
-
 
         s_padinput = tuple([slice(i*b,(i+1)*b+2*p) for i,b,p in zip(index, blocksize, padsize)])
         padded_block = im_pad[s_padinput]
-
-        # print im.shape, padded_block.shape, s_output
 
         yield padded_block, s_input, s_output
 

--- a/setup.py
+++ b/setup.py
@@ -34,6 +34,7 @@ setup(name='gputools',
                                     "ConfigParser",
                                     ],
           ':python_version>="3.0"': ["configparser",
+                                     "scikit-tensor-py3",
                                      ],
       },
 

--- a/tests/convolve/test_convolve.py
+++ b/tests/convolve/test_convolve.py
@@ -39,6 +39,15 @@ def test_convolve():
                 _convolve_rand(dshape, hshape)
 
 
+def test_reflect():
+    image = np.ones((5, 5))
+    image[2, 2] = 0
+    h = np.array([[-1, -2, -1], [0, 0, 0], [1, 2, 1]])
+    out = gputools.convolve(image, h, mode='reflect')
+    npt.assert_allclose(out[0], [0,] * 5)
+    npt.assert_allclose(out[1], [0, 1, 2, 1, 0])
+
+
 def test_small():
     # for N1 in range(10, 40, 7):  # <-- out of resources on macbook pro
     for N1 in range(10, 25, 5):

--- a/tests/convolve/test_convolve_spatial.py
+++ b/tests/convolve/test_convolve_spatial.py
@@ -123,6 +123,14 @@ def test_conv2():
     return im, out, hs
 
 
+def test_conv2_reflect():
+    im = np.zeros((128, 128))
+    Gx, Gy = 4, 8
+    hs = psf_grid_motion(Gx, Gy, 100)
+    out = convolve_spatial2(im, hs, mode='reflect')
+    return im, out, hs
+
+
 def test_conv2_psfs():
     im = np.zeros((384,512))
     im[::32, ::32] = 1.

--- a/tests/convolve/test_convolve_spatial.py
+++ b/tests/convolve/test_convolve_spatial.py
@@ -35,8 +35,6 @@ def psf_grid_const(Gx,Gy,N=21, sx = 0.01, sy = 0.01):
                              for _y in np.linspace(-1,1,Gy)])  for _x in np.linspace(-1,1,Gx)])
 
 
-
-
 def create_psf3(sig = (.3,.3,.3), N = 10, xy_angle = 0.):
     x = np.linspace(-1,1,N+1)[:-1]
     Z,Y,X = np.meshgrid(x,x,x,indexing="ij")
@@ -45,8 +43,6 @@ def create_psf3(sig = (.3,.3,.3), N = 10, xy_angle = 0.):
     h = np.exp(-reduce(np.add,[_X**2/_s**2/2. for _X,_s in zip([Z,Y2,X2],sig)]))
     h *= 1./np.sum(h)
     return h
-
-
 
 
 def make_grid2(hs):
@@ -67,6 +63,7 @@ def psf_grid_const3(Gx,Gy,Gz, N=21, sig = (0.01,0.01,0.01)):
                 for _ in range(Gy)])
                 for _ in range(Gz)])
 
+
 def psf_grid_linear3(Gx,Gy,Gz, N=16):
         return np.stack([np.stack([np.stack([create_psf3(N = N,
                     sig = (0.1+.4*x**2,0.001+.2*x**2,0.001+.2*x**2))
@@ -81,8 +78,6 @@ def psf_grid_const3(Gx,Gy,Gz, N=21, sig = (0.01,0.01,0.01)):
                 for _ in range(Gx)])
                 for _ in range(Gy)])
                 for _ in range(Gz)])
-
-
 
 
 def create_prolate_psf3(N = 21, w = (0,1,0), s1=.4, s2 = .1):
@@ -119,8 +114,6 @@ def make_grid3(hs):
     return im
 
 
-
-
 def test_conv2():
     im = np.zeros((128,128))
     Gx = 4
@@ -139,6 +132,7 @@ def test_conv2_psfs():
     out = convolve_spatial2(im, hs)
     return im, out, hs
 
+
 def test_conv3():
     im = np.zeros((128,64,32))
     Gx = 8
@@ -148,12 +142,14 @@ def test_conv3():
     out = convolve_spatial3(im, hs)
     return im, out, hs
 
+
 def test_conv3_reflect():
     im = np.zeros((128, 64, 32))
     Gx, Gy, Gz = 8, 4, 2
     hs = psf_grid_linear3(Gx, Gy, Gz, 10)
     out = convolve_spatial3(im, hs, mode='reflect')
     return im, out, hs
+
 
 def test_conv3_psfs():
     im = np.zeros((128, 128,128))
@@ -188,7 +184,6 @@ def test_single_z():
     im[4:-4, 4::16, 4::16] = 1.
     hs = np.zeros((16, Nx, Nx))
 
-
     for i in range(Ng):
         for j in range(Ng):
             si = slice(i*(Nx//Ng)-Nh+(Nx//Ng)//2,i*(Nx//Ng)+Nh+1+(Nx//Ng)//2)
@@ -196,7 +191,6 @@ def test_single_z():
             hs[:,sj,si] = np.ones((16,2*Nh+1,2*Nh+1))
 
     hs[:,Nx//Ng//2::Nx//Ng,Nx//Ng//2::Nx//Ng] = 1.
-
 
     out = convolve_spatial3(im, hs, grid_dim = (1, Ng,Ng), pad_factor=2)
     return im, out, hs
@@ -213,7 +207,6 @@ def test_identity2():
 
     h = np.zeros_like(im)
     h[Ny//Ng//2::Ny//Ng,Nx//Ng//2::Nx//Ng] = 1.
-
 
     out = convolve_spatial2(im, h, grid_dim = (Ng,Ng), pad_factor=3)
 

--- a/tests/convolve/test_convolve_spatial.py
+++ b/tests/convolve/test_convolve_spatial.py
@@ -9,7 +9,7 @@ import numpy as np
 from time import time
 from functools import reduce
 from gputools import convolve_spatial2, convolve_spatial3
-import numpy.testing as npt
+
 
 def create_psf(sig=(.1,.1), xy_angle = 0., N = 10):
     x = np.linspace(-1,1,N+1)[:-1]
@@ -146,11 +146,16 @@ def test_conv3():
     Gz = 2
     hs = psf_grid_linear3(Gx,Gy,Gz,10)
     out = convolve_spatial3(im, hs)
-    return im,out, hs
+    return im, out, hs
+
+def test_conv3_reflect():
+    im = np.zeros((128, 64, 32))
+    Gx, Gy, Gz = 8, 4, 2
+    hs = psf_grid_linear3(Gx, Gy, Gz, 10)
+    out = convolve_spatial3(im, hs, mode='reflect')
+    return im, out, hs
 
 def test_conv3_psfs():
-
-    im = np.zeros((128,64,32))
     im = np.zeros((128, 128,128))
     im[::16,::16,::16] = 1.
     Gx = 16


### PR DESCRIPTION
Some googling showed that this corresponds to CLK_ADDRESS_MIRRORED_REPEAT. I have checked that it runs, and that the results are indeed different from constant mode, but not for correctness.