### PR TITLE
fix broken import on newer pyopencl

### DIFF
--- a/gputools/convolve/convolve.py
+++ b/gputools/convolve/convolve.py
@@ -90,7 +90,7 @@ def _convolve_buf(data_g, h_g, res_g=None):
                         data_g.data, h_g.data, res_g.data,
                         *Nhs)
 
-    except cl.cffi_cl.LogicError as e:
+    except LogicError as e:
         # this catches the logic error if the kernel is to big for constant memory
         if e.code == -52:
             kernel_name = "convolve%sd_buf_global" % (len(data_g.shape))
@@ -100,7 +100,7 @@ def _convolve_buf(data_g, h_g, res_g=None):
 
         else:
             raise e
-    except cl.cffi_cl.RuntimeError as e:
+    except RuntimeError as e:
         # this catches the runtime error if the kernel is to big for constant memory
         if e.code == -5:
             kernel_name = "convolve%sd_buf_global" % (len(data_g.shape))

--- a/gputools/convolve/convolve.py
+++ b/gputools/convolve/convolve.py
@@ -10,6 +10,11 @@ from gputools.core.ocltypes import assert_bufs_type
 from gputools.utils.tile_iterator import tile_iterator
 
 import pyopencl as cl
+try:
+    # pyopencl.cffi_cl was removed in version 2018.2
+    from pyopencl.cffi_cl import LogicError, RuntimeError
+except ImportError:
+    from pyopencl import LogicError, RuntimeError
 from ._abspath import abspath
 
 

--- a/gputools/convolve/convolve.py
+++ b/gputools/convolve/convolve.py
@@ -12,9 +12,9 @@ from gputools.utils.tile_iterator import tile_iterator
 import pyopencl as cl
 try:
     # pyopencl.cffi_cl was removed in version 2018.2
-    from pyopencl.cffi_cl import LogicError, RuntimeError
+    from pyopencl.cffi_cl import LogicError, RuntimeError as OCLRuntimeError
 except ImportError:
-    from pyopencl import LogicError, RuntimeError
+    from pyopencl import LogicError, RuntimeError as OCLRuntimeError
 from ._abspath import abspath
 
 
@@ -100,7 +100,7 @@ def _convolve_buf(data_g, h_g, res_g=None):
 
         else:
             raise e
-    except RuntimeError as e:
+    except OCLRuntimeError as e:
         # this catches the runtime error if the kernel is to big for constant memory
         if e.code == -5:
             kernel_name = "convolve%sd_buf_global" % (len(data_g.shape))


### PR DESCRIPTION
Looks like pyopencl removed the cffi_cl module as of version 2018.2 ... so catching Logic and RuntimeErrors in gputools.convolve are failing with newer versions.

As an only-vaguely-related question (can move to issue if desired): When I do trigger a runtime error with a larger psf, I get a kernel panic and my computer logs me out immediately!  :)
hard to debug that one... but any thoughts there?