### PR TITLE
Allow passing in OCL arrays to affine transform

### DIFF
--- a/gputools/core/ocltypes.py
+++ b/gputools/core/ocltypes.py
@@ -150,6 +150,7 @@ def _wrap_OCLArray(cls):
 
 
 def _wrap_OCLImage(cls):
+
     def prepare(arr):
         return np.require(arr, None, "C")
 
@@ -186,6 +187,7 @@ def _wrap_OCLImage(cls):
             res.dtype = arr.dtype
 
         res.num_channels = num_channels
+        res.ndim = arr.ndim
 
         return res
 

--- a/gputools/transforms/transformations.py
+++ b/gputools/transforms/transformations.py
@@ -17,16 +17,16 @@ from ._abspath import abspath
 from mako.template import Template
 
 
-def affine(data, mat=np.identity(4), mode="constant", interpolation="linear"):
+def affine(data, mat=np.identity(4), mode="constant", interpolation="linear", res_g=None):
     """
     affine transform data with matrix mat, which is the inverse coordinate transform matrix  
     (similar to ndimage.affine_transform)
      
     Parameters
     ----------
-    data, ndarray
+    data, ndarray or OCLImage
         3d array to be transformed
-    mat, ndarray 
+    mat, ndarray or OCLArray
         3x3 or 4x4 inverse coordinate transform matrix 
     mode: string 
         boundary mode, one of the following:
@@ -43,14 +43,14 @@ def affine(data, mat=np.identity(4), mode="constant", interpolation="linear"):
         
     Returns
     -------
-    res: ndarray
+    res: ndarray or openCL array
         transformed array (same shape as input)
         
     """
     warnings.warn(
         "gputools.transform.affine: API change as of gputools>= 0.2.8: the inverse of the matrix is now used as in scipy.ndimage.affine_transform")
 
-    if not (isinstance(data, np.ndarray) and data.ndim == 3):
+    if data.ndim != 3:
         raise ValueError("input data has to be a 3d array!")
 
     interpolation_defines = {"linear": ["-D", "SAMPLER_FILTER=CLK_FILTER_LINEAR"],
@@ -70,8 +70,12 @@ def affine(data, mat=np.identity(4), mode="constant", interpolation="linear"):
 
     # reorder matrix, such that x,y,z -> z,y,x (as the kernel is assuming that)
 
-    d_im = OCLImage.from_array(data.astype(np.float32, copy=False))
-    res_g = OCLArray.empty(data.shape, np.float32)
+    if isinstance(data, OCLImage):
+        d_im = data
+    else:
+        d_im = OCLImage.from_array(data.astype(np.float32, copy=False))
+    if res_g is None:
+        res_g = OCLArray.empty(data.shape, np.float32)
     mat_inv_g = OCLArray.from_array(mat.astype(np.float32, copy=False))
 
     prog = OCLProgram(abspath("kernels/affine.cl")
@@ -82,7 +86,10 @@ def affine(data, mat=np.identity(4), mode="constant", interpolation="linear"):
                     data.shape[::-1], None,
                     d_im, res_g.data, mat_inv_g.data)
 
-    return res_g.get()
+    if isinstance(data, OCLImage):
+        return res_g
+    else:
+        return res_g.get()
 
 
 def shift(data, shift=(0, 0, 0), mode="constant", interpolation="linear"):


### PR DESCRIPTION
This gives a massive speedup when repeatedly applying affine transformations to the same volume, as in the case of image registration. (See [this commit](https://github.com/jni/scikit-image/commit/0c6fb69974278dca696a0cb5409a41952c830d2c) on the skimage affine registration PR, which requires these changes.)