### PR TITLE
support python 3.10

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@
 gputools.egg-info/
 dist/
 build/
+.mypy_cache/

--- a/gputools/core/ocltypes.py
+++ b/gputools/core/ocltypes.py
@@ -15,7 +15,6 @@ from gputools import get_device
 from gputools.core.oclprogram import OCLProgram
 
 import pyopencl.clmath as cl_math
-import collections
 
 cl_image_datatype_dict = {cl.channel_type.FLOAT: np.float32,
                           cl.channel_type.UNSIGNED_INT8: np.uint8,
@@ -166,7 +165,7 @@ def _wrap_OCLArray(cls):
         setattr(cls, f, wrap_module_func(cl_array, f))
 
     for f in dir(cl_math):
-        if isinstance(getattr(cl_math, f), collections.Callable):
+        if callable(getattr(cl_math, f)):
             setattr(cls, f, wrap_module_func(cl_math, f))
 
     # cls.sum = sum

--- a/setup.py
+++ b/setup.py
@@ -23,6 +23,7 @@ setup(name='gputools',
           'Programming Language :: Python :: 3.6',
           'Programming Language :: Python :: 3.8',
           'Programming Language :: Python :: 3.9',
+          'Programming Language :: Python :: 3.10',
       ],
       keywords='science image-processing ',
 

--- a/tests/metrics/test_ssim.py
+++ b/tests/metrics/test_ssim.py
@@ -19,7 +19,7 @@ def _time_me(func, dshape, niter = 2):
     return (time()-t)/niter
 
 def time_cpu(dshape, niter=2):
-    return _time_me(compare_ssim, dshape, niter)
+    return _time_me(structural_similarity, dshape, niter)
 
 def time_gpu(dshape, niter=2):
     return _time_me(ssim, dshape, niter)


### PR DESCRIPTION
some very minor changes for python 3.10.
In trying to create a conda-forge package, it currently [fails](https://dev.azure.com/conda-forge/feedstock-builds/_build/results?buildId=421544&view=logs&j=6f142865-96c3-535c-b7ea-873d86b887bd&t=22b0682d-ab9e-55d7-9c79-49f3c3ba4823&l=1767) trying to build py3.10 since there is a `collections.Callable` import.  It's easy enough to support py3.10, so might as well.

This just changes that line to `callable(x)` instead of `isinstance(x, collections.abc.Callable)`, but if you want  me to use the isinstance check instead, let me know.