### PR TITLE
Update numpy pin to account for fixed reikna issue

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -30,10 +30,10 @@ setup(name='gputools',
       install_requires=[
           "six",
           "scipy",
-          "numpy<1.24.0", # bc reikna np.bool issue
+          "numpy<2.0",
           "pyopencl>=2016.1",
           "configparser",
-          "reikna>=0.6.7"],
+          "reikna>=0.8.0"],
 
       extras_require={
           ':python_version<"3.0"': ["scikit-tensor",


### PR DESCRIPTION
Addresses the issue in #32, to allow for more modern versions of numpy 1.

[Reikna](https://github.com/fjarri/reikna) has updated the [handling of numpy bools](https://github.com/fjarri/reikna/pull/64) and released it in [version 0.8.0](https://github.com/fjarri/reikna/releases/tag/v0.8.0).

Tests are passing locally for me.